### PR TITLE
fix(db-controller): シグナルハンドラが正しく動作するように修正

### DIFF
--- a/cmd/sakura-controller/main.go
+++ b/cmd/sakura-controller/main.go
@@ -83,7 +83,7 @@ func main() {
 
 	wg.Add(1)
 	go func(ctx context.Context, wg *sync.WaitGroup, c *sakura.SAKURAController) {
-		wg.Done()
+		defer wg.Done()
 		controller.Start(ctx, logger, controller.Controller(c), time.Second*time.Duration(MainPollingSpanSecondFlag))
 	}(ctx, wg, c)
 


### PR DESCRIPTION
# PRの目的

シグナルハンドラが正しく動作しないため修正する
(SIGTERMなどを受信した際、faultステートに遷移した後に終了するはずだが、faultステートに遷移する仕事が行われない)

# PRによって何が変更されるか

SAKURA Controllerを起動するgo routineにて、本来はコントローラの処理が完了した後にwg.Done()を呼ぶべきだが、
go routine開始時にwg.Done()を呼んでいる。deferを付けることで本来想定した動作となる。

# 動作への影響度

修正点以外の動作の影響はなし

# 動作確認済みかどうか

開発環境で動作確認済み(末尾に確認結果を添付)

# 関連するIssue番号

なし

# 動作確認結果

修正前のログ(faultへ遷移する処理が行われない)
```
[root@dev-sac-is1a-edb-mariadb101 ~]# kill 2776291
[root@dev-sac-is1a-edb-mariadb101 ~]# time=2023-06-19T10:45:20.527+09:00 level=INFO source=/home/ookubo/cvso/distributed-mariadb-controller/cmd/sakura-controller/main.go:106 msg="got stop signal. exiting."
time=2023-06-19T10:45:20.527+09:00 level=INFO source=/home/ookubo/cvso/distributed-mariadb-controller/cmd/sakura-controller/main.go:115 msg="db-controller exited. see you again, bye."

[1]+  Done                    ./sakura-controller --log-level info --db-repilica-password-filepath /root/tools/.db-replica-password
[root@dev-sac-is1a-edb-mariadb101 ~]#
```

修正後のログ(faultへ遷移する処理が正しく行われる)
```
^Ctime=2023-06-19T11:52:21.240+09:00 level=INFO source=/home/ookubo/cvso/distributed-mariadb-controller/cmd/sakura-controller/main.go:106 msg="got stop signal. exiting."
^Ctime=2023-06-19T11:52:22.192+09:00 level=DEBUG source=/home/ookubo/cvso/distributed-mariadb-controller/pkg/controller/sakura/controller.go:205 msg="controller transitions the state" from=replica to=replica
time=2023-06-19T11:52:22.192+09:00 level=DEBUG source=/home/ookubo/cvso/distributed-mariadb-controller/pkg/mariadb/connector.go:199 msg="execute command" command="mysql -e 'show replica status\\G'" callerFn=showReplicaStatusCommand
time=2023-06-19T11:52:22.210+09:00 level=DEBUG source=/home/ookubo/cvso/distributed-mariadb-controller/pkg/controller/sakura/controller.go:130 msg="SAKURAController: OnExit"
time=2023-06-19T11:52:22.210+09:00 level=INFO source=/home/ookubo/cvso/distributed-mariadb-controller/pkg/controller/sakura/controller.go:207 msg="controller transitions the state" from=replica to=fault
time=2023-06-19T11:52:22.210+09:00 level=INFO source=/home/ookubo/cvso/distributed-mariadb-controller/pkg/frrouting/vtysh/bgpd_connector.go:53 msg="execute command" command="vtysh -H /dev/null -c 'conf t' -c 'router bgp' -c 'network 133.242.59.132/32 route-map fault'" callerFn=ConfigureUnicastRouteWithRouteMap
time=2023-06-19T11:52:22.278+09:00 level=INFO source=/home/ookubo/cvso/distributed-mariadb-controller/pkg/nftables/connector.go:58 msg="execute command" command="nft flush chain filter mariadb" callerFn=FlushChain
time=2023-06-19T11:52:22.283+09:00 level=INFO source=/home/ookubo/cvso/distributed-mariadb-controller/pkg/nftables/connector.go:44 msg="execute command" command="nft add rule filter mariadb iifname \"eth0\" tcp dport 3306 reject" callerFn=AddRule
time=2023-06-19T11:52:22.288+09:00 level=INFO source=/home/ookubo/cvso/distributed-mariadb-controller/pkg/process/connector.go:31 msg="execute command" command="pkill -9 -f /usr/sbin/mariadbd" callerFn=KillProcessWithFullName
time=2023-06-19T11:52:22.300+09:00 level=INFO source=/home/ookubo/cvso/distributed-mariadb-controller/pkg/systemd/connector.go:86 msg="execute command" command="systemctl stop mariadb" callerFn=StopService
time=2023-06-19T11:52:22.335+09:00 level=INFO source=/home/ookubo/cvso/distributed-mariadb-controller/pkg/controller/sakura/fault_state.go:56 msg="fault state handler succeed"
time=2023-06-19T11:52:22.335+09:00 level=INFO source=/home/ookubo/cvso/distributed-mariadb-controller/cmd/sakura-controller/main.go:115 msg="db-controller exited. see you again, bye."
```
