### PR TITLE
feat(sakura-controller): レプリケーションソースのポート番号をCLIフラグで指定できるように

### DIFF
--- a/cmd/sakura-controller/cli.go
+++ b/cmd/sakura-controller/cli.go
@@ -19,6 +19,8 @@ var (
 	HTTPAPIServerPortFlag int
 	// PrometheusExporterPortFlag is a cli-flag that specifies the port the prometheus exporter listens.
 	PrometheusExporterPortFlag int
+	// DBReplicaSourcePortFlag is a cli-flag that specifies the port of primary as replication source.
+	DBReplicaSourcePortFlag int
 
 	// EnablePrometheusExporterFlag is a cli-flag that enables the prometheus exporter.
 	EnablePrometheusExporterFlag bool
@@ -37,6 +39,7 @@ func parseAllFlags(args []string) error {
 	fs.IntVar(&MainPollingSpanSecondFlag, "main-polling-span-second", 4, "the span seconds of the loop in main.go")
 	fs.IntVar(&PrometheusExporterPortFlag, "prometheus-exporter-port", 50505, "the port the prometheus exporter listens")
 	fs.IntVar(&HTTPAPIServerPortFlag, "http-api-server-port", 54545, "the port the http api server listens")
+	fs.IntVar(&DBReplicaSourcePortFlag, "db-replica-source-port", 3306, "the port of primary as replication source")
 
 	fs.BoolVar(&EnablePrometheusExporterFlag, "prometheus-exporter", true, "enables the prometheus exporter")
 	fs.BoolVar(&EnableHTTPAPIFlag, "http-api", true, "enables the http api server")

--- a/cmd/sakura-controller/main.go
+++ b/cmd/sakura-controller/main.go
@@ -79,6 +79,8 @@ func main() {
 		c.MariaDBReplicaPassword = dbReplicaPassword
 	}
 
+	c.MariaDBReplicaSourcePort = DBReplicaSourcePortFlag
+
 	wg := new(sync.WaitGroup)
 
 	wg.Add(1)

--- a/pkg/controller/sakura/controller.go
+++ b/pkg/controller/sakura/controller.go
@@ -50,6 +50,8 @@ type SAKURAController struct {
 	m sync.RWMutex
 	// HostAddress is an IP address of the eth0.
 	HostAddress string
+	// DBReplicaSourcePort is the port of primary as replication source.
+	MariaDBReplicaSourcePort int
 	// MariaDBReplicaPassword is credential used by replica to establish replication link for primary
 	MariaDBReplicaPassword string
 	// replicationStatusCheckFailCount is a counter of the MariaDB's replication status checker in replica state.

--- a/pkg/controller/sakura/replica_state.go
+++ b/pkg/controller/sakura/replica_state.go
@@ -12,7 +12,6 @@ const (
 	// if the counter of the controller overs this, the controller goes panic.
 	replicationStatusCheckThreshold = 20
 
-	mariaDBMasterDefaultPort = 13306
 	mariaDBMasterDefaultUser = "repl"
 )
 
@@ -62,7 +61,7 @@ func (c *SAKURAController) triggerRunOnStateChangesToReplica() error {
 	primaryNode := c.CurrentNeighbors.NeighborMatrix[controller.StatePrimary][0]
 	master := mariadb.MasterInstance{
 		Host:     primaryNode.Address,
-		Port:     mariaDBMasterDefaultPort,
+		Port:     c.MariaDBReplicaSourcePort,
 		User:     mariaDBMasterDefaultUser,
 		Password: c.MariaDBReplicaPassword,
 		UseGTID:  mariadb.MasterUseGTIDValueCurrentPos,
@@ -98,7 +97,6 @@ func (c *SAKURAController) triggerRunOnStateChangesToReplica() error {
 func (c *SAKURAController) triggerRunOnStateKeepsReplica() error {
 	if c.replicationStatusCheckFailCount >= replicationStatusCheckThreshold {
 		// we should manually operate the case for recovering.
-		// ref: https://github.sakura.codes/ohkubo/sacloud-multi-az-database/issues/28
 		return fmt.Errorf("reached the maximum retry limit for replication")
 	}
 


### PR DESCRIPTION
# PRの目的

Replica状態に遷移する際に発行する change master to コマンドの master_port に設定する値をCLIフラグで指定できるようにする。

# PRによって何が変更されるか

CLIフラグとして `--db-replica-source-port` を追加し、ポート番号を指定できるようにする。

# 動作への影響度

- ポート番号のデフォルト値が13306から3306に変更となる
  - これまで、当該ポート番号は 13306 がデフォルト値としてハードコードしていた
  - CLIフラグ省略時のデフォルト値を 3306 としている

# 動作確認済みかどうか

開発環境にて動作確認済み

# 関連するIssue番号

なし
