### PR TITLE
Fix minor typos

### DIFF
--- a/cmd/db-controller/cli.go
+++ b/cmd/db-controller/cli.go
@@ -56,7 +56,7 @@ func parseAllFlags(args []string) error {
 
 	fs.StringVar(&logLevelFlag, "log-level", "warning", "the log level(debug/info/warning/error)")
 	fs.StringVar(&lockFilePathFlag, "lock-filepath", "/var/run/db-controller/lock", "the filepath of the exclusive lock")
-	fs.StringVar(&dbReplicaPasswordFilePathFlag, "db-repilica-password-filepath", "/var/run/db-controller/.db-replica-password", "the filepath of the DB replica password")
+	fs.StringVar(&dbReplicaPasswordFilePathFlag, "db-replica-password-filepath", "/var/run/db-controller/.db-replica-password", "the filepath of the DB replica password")
 	fs.StringVar(&globalInterfaceNameFlag, "global-interface-name", "eth0", "the interface name of global")
 	fs.StringVar(&chainNameForDBAclFlag, "chain-name-for-db-acl", "mariadb", "the chain name for DB access control")
 	fs.StringVar(&dbReplicaUserNameFlag, "db-replica-user-name", "repl", "the username for replication")

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -354,7 +354,7 @@ func (c *Controller) getPreviousState() State {
 
 // checkMariaDBHealth checks whether the MariaDB server is healthy or not.
 func (c *Controller) checkMariaDBHealth() dbHealthCheckResult {
-	if err := c.systemdConnector.CheckServiceStatus(mariadb.SystemdSerivceName); err != nil {
+	if err := c.systemdConnector.CheckServiceStatus(mariadb.SystemdServiceName); err != nil {
 		c.logger.Debug("'systemctl status mariadb' exit with returning error", "error", err)
 		return dbHealthCheckResultNG
 	}
@@ -480,7 +480,7 @@ func (c *Controller) startMariaDBService() error {
 	if err := c.mariaDBConnector.RemoveRelayInfo(); err != nil {
 		return err
 	}
-	if err := c.systemdConnector.StartService(mariadb.SystemdSerivceName); err != nil {
+	if err := c.systemdConnector.StartService(mariadb.SystemdServiceName); err != nil {
 		return err
 	}
 

--- a/pkg/controller/fault_state.go
+++ b/pkg/controller/fault_state.go
@@ -49,7 +49,7 @@ func (c *Controller) triggerRunOnStateChangesToFault() error {
 	}
 
 	// [STEP3]: setting MariaDB state
-	if err := c.systemdConnector.KillService(mariadb.SystemdSerivceName); err != nil {
+	if err := c.systemdConnector.KillService(mariadb.SystemdServiceName); err != nil {
 		c.logger.Warn("failed to kill db service but ignored because i'm fault", "error", err)
 	}
 	if err := c.stopMariaDBService(); err != nil {
@@ -85,7 +85,7 @@ func (c *Controller) rejectDatabaseServiceTraffic() error {
 
 // stopMariaDBService stops the mariadb's systemd service.
 func (c *Controller) stopMariaDBService() error {
-	if err := c.systemdConnector.StopService(mariadb.SystemdSerivceName); err != nil {
+	if err := c.systemdConnector.StopService(mariadb.SystemdServiceName); err != nil {
 		return err
 	}
 

--- a/pkg/mariadb/daemon.go
+++ b/pkg/mariadb/daemon.go
@@ -15,7 +15,7 @@
 package mariadb
 
 const (
-	SystemdSerivceName = "mariadb"
+	SystemdServiceName = "mariadb"
 	MasterInfoFilePath = "/var/lib/mysql/master.info"
 	RelayInfoFilePath  = "/var/lib/mysql/relay-log.info"
 )

--- a/pkg/mariadb/fake_connector.go
+++ b/pkg/mariadb/fake_connector.go
@@ -42,7 +42,7 @@ func (c *FakeMariaDBConnector) ChangeMasterTo(master MasterInstance) error {
 
 // ResetAllReplicas implements mariadb.Connector
 func (c *FakeMariaDBConnector) ResetAllReplicas() error {
-	c.Timestamp["ResetAllRelicas"] = time.Now()
+	c.Timestamp["ResetAllReplicas"] = time.Now()
 	return nil
 }
 

--- a/pkg/nftables/connector.go
+++ b/pkg/nftables/connector.go
@@ -83,7 +83,7 @@ func (c *nftCommandConnector) FlushChain(
 func (c *nftCommandConnector) CreateChain(
 	chain string,
 ) error {
-	// nft add chain comand returns ok if the chain is already exist.
+	// nft add chain command returns ok if the chain is already exist.
 	name := "nft"
 	args := []string{"add", "chain", builtinTableFilter, chain, "{ type filter hook input priority 0; }"}
 	c.logger.Info("execute command", "name", name, "args", args)

--- a/pkg/systemd/connector.go
+++ b/pkg/systemd/connector.go
@@ -28,7 +28,7 @@ const (
 
 // Connector is an interface that communicates with systemd.
 type Connector interface {
-	// StartSerivce starts a systemd service.
+	// StartService starts a systemd service.
 	StartService(serviceName string) error
 
 	// StopService stops a systemd service.
@@ -51,7 +51,7 @@ func NewDefaultConnector(logger *slog.Logger) Connector {
 	return &systemCtlConnector{logger: logger}
 }
 
-// StartSerivce implements Connector
+// StartService implements Connector
 func (c *systemCtlConnector) StartService(
 	serviceName string,
 ) error {


### PR DESCRIPTION
Note: 修正点の中に利用者に影響がある修正が含まれます。

CLIのフラグ名を修正していますので、もしフラグを利用している箇所があった場合は修正が必要になります。
- `db-repilica-password-filepath` -> `db-replica-password-filepath`